### PR TITLE
Replaced reference to Script off process to NodeScript to mirror a Node c

### DIFF
--- a/lib/alfred/meta/commands/add_index.js
+++ b/lib/alfred/meta/commands/add_index.js
@@ -1,4 +1,4 @@
-var Script = process.binding('evals').Script;
+var Script = process.binding('evals').NodeScript;
 
 var index_wrapper = require('../index_wrapper');
 


### PR DESCRIPTION
Node recently changed the reference to Script to NodeScript to avoid a conflict with V8
